### PR TITLE
Fixed bug: migrating from TFS to TFS project showed 'object reference…

### DIFF
--- a/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
+++ b/src/VstsSyncMigrator.Core/Execution/ComponentContext/WorkItemStoreContext.cs
@@ -76,7 +76,7 @@ namespace VstsSyncMigrator.Engine
             {
                 return foundWis[workItemToFind.Id];
             }
-            if (workItemToFind.Fields.Contains(reflectedWotkItemIdField) && !string.IsNullOrEmpty( workItemToFind.Fields[reflectedWotkItemIdField].Value.ToString()))
+            if (workItemToFind.Fields.Contains(reflectedWotkItemIdField) && !string.IsNullOrEmpty( workItemToFind.Fields[reflectedWotkItemIdField]?.Value?.ToString()))
             {
                 string rwiid = workItemToFind.Fields[reflectedWotkItemIdField].Value.ToString();
                 int idToFind = GetReflectedWorkItemId(workItemToFind, reflectedWotkItemIdField);


### PR DESCRIPTION
… not set to an instance of an object' error in log. Fixed it by using null-conditional operators.

The code was checking if a string (reflected id field value) was null. ToString() was used to convert field value (Value property of field) to string. If the field was null, a 'object reference not set to an instance of an object' exception. An exception would end up in the log being meaningless to a user not displayed to the user. If the value was null, then the ToString() would cause an exception, being called on a null object.